### PR TITLE
Minor API changes after the first draft

### DIFF
--- a/Neo4j.Driver/Neo4j.Driver.Tests/StatementRunnerTests.cs
+++ b/Neo4j.Driver/Neo4j.Driver.Tests/StatementRunnerTests.cs
@@ -16,6 +16,7 @@
 // limitations under the License.
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Neo4j.Driver.Internal;
 using Neo4j.Driver.V1;
@@ -30,11 +31,16 @@ namespace Neo4j.Driver.Tests
             public string Statement { private set; get; }
             public IDictionary<string, object> Parameters { private set; get; } 
 
-            public override IStatementResult Run(string statement, IDictionary<string,object> parameters = null)
+            public override IStatementResult Run(Statement statement)
             {
-                Statement = statement;
-                Parameters = parameters;
+                Statement = statement.Text;
+                Parameters = statement.Parameters;
                 return null; // nah, I do not care
+            }
+
+            public override Task<IStatementResultAsync> RunAsync(Statement statement)
+            {
+                throw new System.NotImplementedException();
             }
 
             public MyStatementRunner() : base(null)

--- a/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/Driver.cs
@@ -39,7 +39,7 @@ namespace Neo4j.Driver.Internal
             _retryLogic = retryLogic;
         }
 
-        public ISessionAsync Session(AccessMode defaultMode=AccessMode.Write, string bookmark = null)
+        public ISession Session(AccessMode defaultMode=AccessMode.Write, string bookmark = null)
         {
             return Session(defaultMode, Bookmark.From(bookmark, _logger));
         }
@@ -69,17 +69,17 @@ namespace Neo4j.Driver.Internal
             throw new ObjectDisposedException(GetType().Name, "Cannot open a new session on a driver that is already disposed.");
         }
 
-        public ISessionAsync Session(AccessMode defaultMode, IEnumerable<string> bookmarks)
+        public ISession Session(AccessMode defaultMode, IEnumerable<string> bookmarks)
         {
             return Session(defaultMode, Bookmark.From(bookmarks));
         }
 
-        public ISessionAsync Session(IEnumerable<string> bookmarks)
+        public ISession Session(IEnumerable<string> bookmarks)
         {
             return Session(AccessMode.Write, bookmarks);
         }
 
-        private ISessionAsync Session(AccessMode defaultMode, Bookmark bookmark)
+        private ISession Session(AccessMode defaultMode, Bookmark bookmark)
         {
             if (_disposeCalled)
             {

--- a/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
+++ b/Neo4j.Driver/Neo4j.Driver/Internal/StatementRunner.cs
@@ -14,30 +14,44 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Neo4j.Driver.V1;
 
 namespace Neo4j.Driver.Internal
 {
-    internal abstract class StatementRunner : LoggerBase
+    internal abstract class StatementRunner : LoggerBase, IStatementRunner, IStatementRunnerAsync
     {
         protected StatementRunner(ILogger logger) : base(logger)
         {
         }
 
-        public abstract IStatementResult Run(string statement, IDictionary<string, object> parameters = null);
+        public abstract IStatementResult Run(Statement statement);
+        public abstract Task<IStatementResultAsync> RunAsync(Statement statement);
 
-        public IStatementResult Run(Statement statement)
+        public IStatementResult Run(string statement, IDictionary<string, object> parameters = null)
         {
-            return Run(statement.Text, statement.Parameters);
+            return Run(new Statement(statement, parameters));
         }
 
         public IStatementResult Run(string statement, object parameters)
         {
-            var paramDictionary = parameters.ToDictionary();
-            return Run(statement, paramDictionary);
+            var cypherStatement = new Statement(statement, parameters.ToDictionary());
+            return Run(cypherStatement);
+        }
+
+        public Task<IStatementResultAsync> RunAsync(string statement, IDictionary<string, object> parameters = null)
+        {
+            return RunAsync(new Statement(statement, parameters));
+        }
+
+        public Task<IStatementResultAsync> RunAsync(string statement, object parameters)
+        {
+            return RunAsync(new Statement(statement, parameters.ToDictionary()));
         }
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/V1/IDriver.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/IDriver.cs
@@ -44,8 +44,8 @@ namespace Neo4j.Driver.V1
         /// <param name="bookmark">A reference to a previous transaction. If the bookmark is provided,
         /// then the server hosting is at least as up-to-date as the transaction referenced by the supplied bookmark.
         /// Specify a bookmark if the statement excuted inside this session need to be chained after statements from other sessions.</param>
-        /// <returns>An <see cref="ISessionAsync"/> that could be used to execute statements.</returns>
-        ISessionAsync Session(AccessMode defaultMode = AccessMode.Write, string bookmark = null);
+        /// <returns>An <see cref="ISession"/> that could be used to execute statements.</returns>
+        ISession Session(AccessMode defaultMode = AccessMode.Write, string bookmark = null);
 
         /// <summary>
         /// Obtain a session with the default <see cref="AccessMode"/> and a series of start bookmars.
@@ -56,8 +56,8 @@ namespace Neo4j.Driver.V1
         /// <param name="bookmarks">References to previous transactions. If the bookmarks are provided,
         /// then the server hosting is at least as up-to-date as the transaction referenced by the supplied bookmarks.
         /// Specify bookmarks if the statement excuted inside this session need to be chained after statements from other sessions.</param>
-        /// <returns>An <see cref="ISessionAsync"/> that could be used to execute statements.</returns>
-        ISessionAsync Session(AccessMode defaultMode, IEnumerable<string> bookmarks);
+        /// <returns>An <see cref="ISession"/> that could be used to execute statements.</returns>
+        ISession Session(AccessMode defaultMode, IEnumerable<string> bookmarks);
 
         /// <summary>
         /// Obtain a session with the default <see cref="AccessMode.Write"/> access mode and a series of start bookmars.
@@ -65,8 +65,8 @@ namespace Neo4j.Driver.V1
         /// <param name="bookmarks">References to previous transactions. If the bookmarks are provided,
         /// then the server hosting is at least as up-to-date as the transaction referenced by the supplied bookmarks.
         /// Specify bookmarks if the statement excuted inside this session need to be chained after statements from other sessions.</param>
-        /// <returns>An <see cref="ISessionAsync"/> that could be used to execute statements.</returns>
-        ISessionAsync Session(IEnumerable<string> bookmarks);
+        /// <returns>An <see cref="ISession"/> that could be used to execute statements.</returns>
+        ISession Session(IEnumerable<string> bookmarks);
     }
     /// <summary>
     /// Used by driver to route a cypher statement to a write server or a read server.

--- a/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/ISession.cs
@@ -32,7 +32,7 @@ namespace Neo4j.Driver.V1
     /// Session objects are not thread safe, if you want to run concurrent operations against the database,
     /// simply create multiple session objects.
     /// </summary>
-    public interface ISession : IStatementRunner
+    public interface ISession : IStatementRunner, ISessionAsync
     {
         /// <summary>
         /// Begin a new transaction in this session. A session can have at most one transaction running at a time, if you
@@ -135,7 +135,7 @@ namespace Neo4j.Driver.V1
     /// It is designed to minimize the complexity of the code you need to write to use transactions in a safe way, ensuring
     /// that transactions are properly rolled back even if there is an exception while the transaction is running.
     /// </summary>
-    public interface ITransaction : IStatementRunner
+    public interface ITransaction : IStatementRunner, ITransactionAsync
     {
         /// <summary>
         /// Mark this transaction as successful. You must call this method before calling <see cref="IDisposable.Dispose"/> to have your

--- a/Neo4j.Driver/Neo4j.Driver/V1/ISessionAsync.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/ISessionAsync.cs
@@ -19,7 +19,7 @@ namespace Neo4j.Driver.V1
     /// Session objects are not thread safe, if you want to run concurrent operations against the database,
     /// simply create multiple session objects.
     /// </summary>
-    public interface ISessionAsync : ISession, IStatementRunnerAsync
+    public interface ISessionAsync : IStatementRunnerAsync
     {
         /// <summary>
         /// Asynchronously begin a new transaction in this session. A session can have at most one transaction running at a time, if you
@@ -74,7 +74,7 @@ namespace Neo4j.Driver.V1
     /// <remarks>
     /// <see cref="ISessionAsync"/> and <see cref="ITransactionAsync"/>
     /// </remarks>
-    public interface IStatementRunnerAsync : IStatementRunner
+    public interface IStatementRunnerAsync
     {
         /// <summary>
         /// 
@@ -117,20 +117,17 @@ namespace Neo4j.Driver.V1
     /// It is designed to minimize the complexity of the code you need to write to use transactions in a safe way, ensuring
     /// that transactions are properly rolled back even if there is an exception while the transaction is running.
     /// </summary>
-    public interface ITransactionAsync : ITransaction, IStatementRunnerAsync
+    public interface ITransactionAsync : IStatementRunnerAsync
     {
         /// <summary>
-        /// Asynchronously mark this transaction as successful. You must call this method before calling <see cref="IDisposable.Dispose"/> to have your
-        /// transaction committed.
+        /// Asynchronously commit this transaction.
         /// </summary>
-        Task SuccessAsync();
+        Task CommitAsync();
 
         /// <summary>
-        /// Asynchronously mark this transaction as failed. Calling <see cref="IDisposable.Dispose"/> will roll back the transaction.
-        ///
-        /// Marking a transaction as failed is irreversable and guarantees that subsequent calls to <see cref="SuccessAsync"/> will not change it's status.
+        /// Asynchronously roll back this transaction.
         /// </summary>
-        Task FailureAsync();
+        Task RollbackAsync();
 
     }
 

--- a/Neo4j.Driver/Neo4j.Driver/V1/Statement.cs
+++ b/Neo4j.Driver/Neo4j.Driver/V1/Statement.cs
@@ -24,13 +24,6 @@ namespace Neo4j.Driver.V1
     /// </summary>
     public class Statement
     {
-        private static IDictionary<string, object> NoParameter { get; }
-
-        static Statement()
-        {
-            NoParameter = new Dictionary<string, object>();
-        }
-         
         /// <summary>
         /// Gets the statement's text.
         /// </summary>
@@ -48,12 +41,12 @@ namespace Neo4j.Driver.V1
         public Statement(string text, IDictionary<string, object> parameters = null)
         {
             Text = text;
-            Parameters = parameters ?? NoParameter;
+            Parameters = parameters;
         }
 
         public override string ToString()
         {
-            return $"`{Text}`, {Parameters.ToContentString()}";
+            return $"`{Text}`, {Parameters.ValueToString()}";
         }
     }
 


### PR DESCRIPTION
Moved `ISession` to extend `ISessionAsync`, same for I`Transaction` and `ITransactionAsync`
Renamed `SuccessAsync` and `FailureAsync` to `CommitAsync` and `RollbackAsync`
Added experimenting implementation of `Session.RunTransactionAsync`